### PR TITLE
#8 ingress-nginx 추가

### DIFF
--- a/k8s/ingress-srv.yaml
+++ b/k8s/ingress-srv.yaml
@@ -1,0 +1,61 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-service
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  rules:
+    - host: chatlink.dev
+      http:
+        paths:
+          - path: /api/chat(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: chat-srv
+                port:
+                  number: 3000
+          - path: /api/users(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-srv
+                port:
+                  number: 3000
+          - path: /api/notification(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: notification-srv
+                port:
+                  number: 3000
+          - path: /api/message(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: message-srv
+                port:
+                  number: 3000
+          - path: /api/community(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: community-srv
+                port:
+                  number: 3000
+          - path: /api/search(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: search-srv
+                port:
+                  number: 3000
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: client-srv
+                port:
+                  number: 3000


### PR DESCRIPTION
#8 

ingress-srv.yaml 추가

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-service
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/use-regex: "true"
spec:
  rules:
    - host: chatlink.dev
      http:
        paths:
          - path: /api/chat(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: chat-srv
                port:
                  number: 3000
          - path: /api/users(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: auth-srv
                port:
                  number: 3000
          - path: /api/notification(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: notification-srv
                port:
                  number: 3000
          - path: /api/message(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: message-srv
                port:
                  number: 3000
          - path: /api/community(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: community-srv
                port:
                  number: 3000
          - path: /api/search(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: search-srv
                port:
                  number: 3000
          - path: /(.*)
            pathType: Prefix
            backend:
              service:
                name: client-srv
                port:
                  number: 3000
```